### PR TITLE
Replace sklearn.externals.joblib by joblib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 scikit-learn>=0.20
 pytest
 nose
+joblib

--- a/spherecluster/spherical_kmeans.py
+++ b/spherecluster/spherical_kmeans.py
@@ -2,8 +2,10 @@ import warnings
 
 import numpy as np
 import scipy.sparse as sp
+from joblib import Parallel, delayed
 
 from sklearn.cluster import KMeans
+from sklearn.cluster import _k_means
 from sklearn.cluster.k_means_ import (
     _check_sample_weight,
     _init_centroids,
@@ -11,12 +13,10 @@ from sklearn.cluster.k_means_ import (
     _tolerance,
     _validate_center_shape,
 )
-from sklearn.utils import check_array, check_random_state
-from sklearn.utils.validation import _num_samples
-from sklearn.cluster import _k_means
 from sklearn.preprocessing import normalize
-from sklearn.externals.joblib import Parallel, delayed
+from sklearn.utils import check_array, check_random_state
 from sklearn.utils.extmath import row_norms, squared_norm
+from sklearn.utils.validation import _num_samples
 
 
 def _spherical_kmeans_single_lloyd(

--- a/spherecluster/von_mises_fisher_mixture.py
+++ b/spherecluster/von_mises_fisher_mixture.py
@@ -2,22 +2,21 @@ import warnings
 
 import numpy as np
 import scipy.sparse as sp
-from scipy.special import iv  # modified Bessel function of first kind, I_v
+from joblib import Parallel, delayed
 from numpy import i0  # modified Bessel function of first kind order 0, I_0
+from scipy.special import iv  # modified Bessel function of first kind, I_v
 from scipy.special import logsumexp
 
 from sklearn.base import BaseEstimator, ClusterMixin, TransformerMixin
 from sklearn.cluster.k_means_ import _init_centroids, _tolerance, _validate_center_shape
+from sklearn.metrics.pairwise import cosine_distances
+from sklearn.preprocessing import normalize
+from sklearn.utils import check_array, check_random_state, as_float_array
+from sklearn.utils.extmath import squared_norm
 from sklearn.utils.validation import FLOAT_DTYPES
 from sklearn.utils.validation import check_is_fitted
-from sklearn.utils import check_array, check_random_state, as_float_array
-from sklearn.preprocessing import normalize
-from sklearn.utils.extmath import squared_norm
-from sklearn.metrics.pairwise import cosine_distances
-from sklearn.externals.joblib import Parallel, delayed
 
 from . import spherical_kmeans
-
 
 MAX_CONTENTRATION = 1e10
 


### PR DESCRIPTION
When importing anything from `spherical_kmeans.py` or `von_mises_fisher_mixture.py`, `sklearn` throws the following warning:

`/home/piplab/anaconda3/lib/python3.7/site-packages/sklearn/externals/joblib/__init__.py:15: DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.
  warnings.warn(msg, category=DeprecationWarning)`

I replaced `sklearn.externals.joblib` with `joblib`