### PR TITLE
Define labels as integers for vonMisesFisher

### DIFF
--- a/spherecluster/von_mises_fisher_mixture.py
+++ b/spherecluster/von_mises_fisher_mixture.py
@@ -38,7 +38,7 @@ def _labels_inertia(X, centers):
     n_examples, n_features = X.shape
     n_clusters, n_features = centers.shape
 
-    labels = np.zeros((n_examples,))
+    labels = np.zeros((n_examples,), dtype=int)
     inertia = np.zeros((n_examples,))
 
     for ee in range(n_examples):

--- a/spherecluster/von_mises_fisher_mixture.py
+++ b/spherecluster/von_mises_fisher_mixture.py
@@ -487,7 +487,7 @@ def _movMF(
             break
 
     # labels come for free via posterior
-    labels = np.zeros((n_examples,))
+    labels = np.zeros((n_examples,), dtype=int)
     for ee in range(n_examples):
         labels[ee] = np.argmax(posterior[:, ee])
 


### PR DESCRIPTION
Define cluster labels as integers, instead of floats.
Solves https://github.com/jasonlaska/spherecluster/issues/27