### PR TITLE
Fix sklearn to 0.23.1 (last working version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
-scikit-learn>=0.20
+scikit-learn==0.21.3
 pytest
 nose


### PR DESCRIPTION
As a quick fix for issue #29, I fixed `sklearn` in the requirements to the last version which I got working without changing `spherecluster` substantially. Ideally, one would update this codebase to work with later versions of`sklearn`, but this seems to be more than a minor task (see discussion in #29).