### PR TITLE
Solve compatibility issues with scikit>=0.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-scikit-learn>=0.22
+scikit-learn>=0.24
 pytest
 nose
 joblib

--- a/spherecluster/tests/test_common.py
+++ b/spherecluster/tests/test_common.py
@@ -3,4 +3,4 @@ from spherecluster import SphericalKMeans
 
 
 def test_estimator_spherical_k_means():
-    return check_estimator(SphericalKMeans)
+    return check_estimator(SphericalKMeans())


### PR DESCRIPTION
Hi !
First of all thanks a lot for implementing these algorithms !

I've taken care of solving issue #29 which came from a change in scikit's code for kmeans with the release of scikit v0.23. As mentioned by @dominikstrb in PR #31, fixing the issue went a little deeper than simply replacing `sklearn.clusters.k_means_` by `sklearn.clusters._kmeans` mainly because `_init_centroids` is now a class method of `KMeans` (the same issue is for instance mentioned [here](https://github.com/alexandrebarachant/pyRiemann/issues/92)).

In any case, I hope this help ! This is only the second time I contribute to a public repo so I am 100% open to feedback.

Cheers,

Romain F
